### PR TITLE
feat: add Dependabot configuration with dependency grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,115 @@
+version: 2
+updates:
+  # Go dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    # Group all Go module updates into a single PR
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "go"
+    reviewers:
+      - "rbellamy"
+    
+  # Go dependencies for the processor module
+  - package-ecosystem: "gomod"
+    directory: "/processor/metricsinferenceprocessor"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    # Group all Go module updates into a single PR
+    groups:
+      processor-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "go"
+      - "processor"
+    reviewers:
+      - "rbellamy"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    # Group all GitHub Actions updates into a single PR
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "rbellamy"
+
+  # Docker dependencies
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"
+    reviewers:
+      - "rbellamy"
+
+  # Python dependencies for demo models
+  - package-ecosystem: "pip"
+    directory: "/demo/models/kalman-filter"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    # Group all Python updates into a single PR
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+      - "demo"
+    reviewers:
+      - "rbellamy"


### PR DESCRIPTION
## Summary
- Adds comprehensive Dependabot configuration for automated dependency updates
- Implements dependency grouping to consolidate updates into single PRs per ecosystem
- Covers all package ecosystems used in the project

## Configuration Details

### Package Ecosystems Configured:
1. **Go modules** (root and processor module)
   - Weekly updates on Mondays at 9 AM ET
   - All Go dependencies grouped into single PR per module
   - Conventional commit messages with "chore" prefix

2. **GitHub Actions**
   - Weekly updates on Mondays at 9 AM ET
   - All action updates grouped into single PR
   - Conventional commit messages with "ci" prefix

3. **Docker**
   - Weekly updates for base images
   - Conventional commit messages with "chore" prefix

4. **Python** (demo models)
   - Weekly updates for Kalman filter model dependencies
   - All Python dependencies grouped into single PR
   - Conventional commit messages with "chore" prefix

### Key Features:
- **Dependency Grouping**: Each ecosystem's updates are rolled into a single PR to reduce PR noise
- **Consistent Schedule**: All updates run weekly on Monday mornings
- **Proper Labeling**: Each PR gets appropriate labels for easy filtering
- **Conventional Commits**: Follows project's commit message conventions
- **Automatic Assignment**: PRs assigned to @rbellamy for review

## Additional Steps Required
After merging this PR, you'll need to:
1. Enable the dependency graph in repository settings (Settings → Security → Dependency graph)
2. Enable Dependabot security updates if desired (Settings → Security → Dependabot)

This configuration will help keep dependencies up to date while minimizing the maintenance burden through intelligent grouping.